### PR TITLE
Fixes link to sponsorship pamphlet

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
           <ul id="js-navigation-menu" class="navigation-menu show">
             <li class="nav-link"><a href='/index.html'>Home</a></li>
             <li class="nav-link"><a href='https://goo.gl/12KG1u' target='_blank'>Call 4 Papers</a></li>
-            <li class="nav-link"><a href='/index.html#sponsor'>Sponsor!</a></li>
+            <li class="nav-link"><a href='/sponsor.pdf'>Sponsor!</a></li>
             <li class="nav-link"><a href='/coc.html'>Code of Conduct</a></li>
             <li class="nav-link"><a href="http://twitter.com/conferenciaror">@conferenciaror</a> </li>
           </ul>


### PR DESCRIPTION
Thank for the heads up Jaime.

The link on navigation is _intended_ to be a local link to the anchor at https://github.com/aprodeweb/conferenciaror.es/blob/gh-pages/index.html#L71 instead of a direct link to the pamphlet with no explanation.

Unless you think it is a bad idea, I feel prone to leave it as is, so visitors read the explanatio an decide if they want to download the file or not.
